### PR TITLE
model `python_path` as a vector, not a string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -14,7 +14,7 @@ which may differ from later revisions.
 ## Prerequisites
 
 * `dicej/spin` branch `wasi-http`
-* `componentize-py` 0.3.3 or later
+* `componentize-py` 0.4.0
 * `Rust`, for installing `Spin`
 
 ```

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -12,7 +12,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime-py` 13 or later
-* `componentize-py` 0.3.3 or later
+* `componentize-py` 0.4.0
 * `NumPy`, built for WASI
 
 Note that we must build `wasmtime-py` from source until version 13 has been

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.3.3"
+version = "0.4.0"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/python.rs
+++ b/src/python.rs
@@ -10,7 +10,7 @@ use {
 fn python_componentize(
     wit_path: PathBuf,
     world: Option<&str>,
-    python_path: &str,
+    python_path: Vec<&str>,
     app_name: &str,
     output_path: PathBuf,
 ) -> PyResult<()> {
@@ -18,7 +18,7 @@ fn python_componentize(
         Runtime::new()?.block_on(crate::componentize(
             &wit_path,
             world,
-            python_path,
+            &python_path,
             app_name,
             &output_path,
             None,

--- a/src/test.rs
+++ b/src/test.rs
@@ -54,10 +54,10 @@ async fn make_component(
     crate::componentize(
         &tempdir.path().join("app.wit"),
         None,
-        tempdir
+        &[tempdir
             .path()
             .to_str()
-            .ok_or_else(|| anyhow!("unable to parse temporary directory path as UTF-8"))?,
+            .ok_or_else(|| anyhow!("unable to parse temporary directory path as UTF-8"))?],
         "app",
         &tempdir.path().join("app.wasm"),
         add_to_linker,


### PR DESCRIPTION
This allows us to avoid dealing with Windows- vs. Unix-style path delimiters and makes the CLI more uniform.