### PR TITLE
call host directly to get runtime env vars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -14,7 +14,7 @@ which may differ from later revisions.
 ## Prerequisites
 
 * `dicej/spin` branch `wasi-http`
-* `componentize-py` 0.4.0
+* `componentize-py` 0.4.1
 * `Rust`, for installing `Spin`
 
 ```

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -12,7 +12,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime-py` 13 or later
-* `componentize-py` 0.4.0
+* `componentize-py` 0.4.1
 * `NumPy`, built for WASI
 
 Note that we must build `wasmtime-py` from source until version 13 has been

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.4.0"
+version = "0.4.1"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod util;
 static NATIVE_EXTENSION_SUFFIX: &str = ".cpython-311-wasm32-wasi.so";
 
 wasmtime::component::bindgen!({
-    path: "wit/init.wit",
+    path: "wit",
     world: "init",
     async: true
 });

--- a/wit/deps/cli/environment.wit
+++ b/wit/deps/cli/environment.wit
@@ -1,0 +1,20 @@
+package wasi:cli
+
+interface environment {
+  /// Get the POSIX-style environment variables.
+  ///
+  /// Each environment variable is provided as a pair of string variable names
+  /// and string value.
+  ///
+  /// Morally, these are a value import, but until value imports are available
+  /// in the component model, this import function should return the same
+  /// values each time it is called.
+  get-environment: func() -> list<tuple<string, string>>
+
+  /// Get the POSIX-style arguments to the program.
+  get-arguments: func() -> list<string>
+
+  /// Return a path that programs should use as their initial current working
+  /// directory, interpreting `.` as shorthand for this.
+  initial-cwd: func() -> option<string>
+}

--- a/wit/init.wit
+++ b/wit/init.wit
@@ -1,6 +1,8 @@
 package componentize-py:init
 
 world init {
+    import wasi:cli/environment
+
     export exports: interface {
         record function-export {
             protocol: string,


### PR DESCRIPTION
The old trick of calling `__wasm_call_ctors` to force libc to re-initialize its state won't work anymore since the runtime is a shared library which has its own `__wasm_call_ctors` (which does nothing), and there's no way to tell `wit-component` we want to call libc's version instead.